### PR TITLE
Enable hub controller

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -56,6 +56,8 @@ KUBECONFIG=$TOP_HUB_CONFIG ./undeploy_hub_of_hubs.sh
 
 # Hubs to connect to Hub of Hubs
 
+This step is an optional step. the Hub-of-Hubs agent can be deployed automatically if the Hubs are the managed clusters of the Hub of Hubs.
+
 ## Deploying a Hub-of-Hubs agent
 
 ```

--- a/deploy/deploy_hub_of_hubs.sh
+++ b/deploy/deploy_hub_of_hubs.sh
@@ -84,6 +84,9 @@ function deploy_hoh_controllers() {
   git clone https://github.com/stolostron/hub-of-hubs-addon.git
   cd hub-of-hubs-addon
   git checkout $branch
+  # set HUB_OF_HUBS_VERSION with $TAG
+  mv ./deploy/deployment.yaml ./deploy/deployment.yaml.tmpl
+  envsubst < ./deploy/deployment.yaml.tmpl > ./deploy/deployment.yaml
   kubectl apply -k ./deploy
   cd ..
   rm -rf hub-cluster-controller

--- a/deploy/deploy_hub_of_hubs.sh
+++ b/deploy/deploy_hub_of_hubs.sh
@@ -9,21 +9,25 @@ set -o nounset
 echo "using kubeconfig $KUBECONFIG"
 script_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 acm_namespace=open-cluster-management
+branch=$TAG
+if [ $TAG == "latest" ]; then
+  branch="main"
+fi
 
 function deploy_hoh_resources() {
   # apply the HoH config CRD
   hoh_config_crd_exists=$(kubectl get crd configs.hub-of-hubs.open-cluster-management.io --ignore-not-found)
   if [[ ! -z "$hoh_config_crd_exists" ]]; then # if exists replace with the requested tag
-    kubectl replace -f "https://raw.githubusercontent.com/stolostron/hub-of-hubs-crds/$TAG/crds/hub-of-hubs.open-cluster-management.io_config_crd.yaml"
+    kubectl replace -f "https://raw.githubusercontent.com/stolostron/hub-of-hubs-crds/$branch/crds/hub-of-hubs.open-cluster-management.io_config_crd.yaml"
   else
-    kubectl apply -f "https://raw.githubusercontent.com/stolostron/hub-of-hubs-crds/$TAG/crds/hub-of-hubs.open-cluster-management.io_config_crd.yaml"
+    kubectl apply -f "https://raw.githubusercontent.com/stolostron/hub-of-hubs-crds/$branch/crds/hub-of-hubs.open-cluster-management.io_config_crd.yaml"
   fi
 
   # create namespace if not exists
   kubectl create namespace hoh-system --dry-run=client -o yaml | kubectl apply -f -
 
   # apply default HoH config CR
-  kubectl apply -f "https://raw.githubusercontent.com/stolostron/hub-of-hubs-crds/$TAG/cr-examples/hub-of-hubs.open-cluster-management.io_config_cr.yaml" -n hoh-system
+  kubectl apply -f "https://raw.githubusercontent.com/stolostron/hub-of-hubs-crds/$branch/cr-examples/hub-of-hubs.open-cluster-management.io_config_cr.yaml" -n hoh-system
 }
 
 function deploy_transport() {
@@ -44,9 +48,9 @@ function deploy_hoh_controllers() {
 
   kubectl delete secret hub-of-hubs-database-secret -n "$acm_namespace" --ignore-not-found
   kubectl create secret generic hub-of-hubs-database-secret -n "$acm_namespace" --from-literal=url="$database_url_hoh"
-  curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-spec-sync/$TAG/deploy/operator.yaml.template" |
+  curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-spec-sync/$branch/deploy/operator.yaml.template" |
     REGISTRY=quay.io/open-cluster-management-hub-of-hubs IMAGE_TAG=$TAG COMPONENT=hub-of-hubs-spec-sync envsubst | kubectl apply -f - -n "$acm_namespace"
-  curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-status-sync/$TAG/deploy/operator.yaml.template" |
+  curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-status-sync/$branch/deploy/operator.yaml.template" |
     REGISTRY=quay.io/open-cluster-management-hub-of-hubs IMAGE_TAG=$TAG COMPONENT=hub-of-hubs-status-sync envsubst | kubectl apply -f - -n "$acm_namespace"
 
   kubectl delete secret hub-of-hubs-database-transport-bridge-secret -n "$acm_namespace" --ignore-not-found
@@ -61,31 +65,46 @@ function deploy_hoh_controllers() {
     transport_type=kafka
   fi
 
-  curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-spec-transport-bridge/$TAG/deploy/hub-of-hubs-spec-transport-bridge.yaml.template" |
+  curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-spec-transport-bridge/$branch/deploy/hub-of-hubs-spec-transport-bridge.yaml.template" |
     TRANSPORT_TYPE="${transport_type}" IMAGE="quay.io/open-cluster-management-hub-of-hubs/hub-of-hubs-spec-transport-bridge:$TAG" envsubst | kubectl apply -f - -n "$acm_namespace"
-  curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-status-transport-bridge/$TAG/deploy/hub-of-hubs-status-transport-bridge.yaml.template" |
+  curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-status-transport-bridge/$branch/deploy/hub-of-hubs-status-transport-bridge.yaml.template" |
     TRANSPORT_TYPE="${transport_type}" IMAGE="quay.io/open-cluster-management-hub-of-hubs/hub-of-hubs-status-transport-bridge:$TAG" envsubst | kubectl apply -f - -n "$acm_namespace"
 }
 
 function deploy_rbac() {
-  curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-rbac/$TAG/data.json" > ${script_dir}/data.json
-  curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-rbac/$TAG/role_bindings.yaml" > ${script_dir}/role_bindings.yaml
-  curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-rbac/$TAG/opa_authorization.rego" > ${script_dir}/opa_authorization.rego
+  curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-rbac/$branch/data.json" > ${script_dir}/data.json
+  curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-rbac/$branch/role_bindings.yaml" > ${script_dir}/role_bindings.yaml
+  curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-rbac/$branch/opa_authorization.rego" > ${script_dir}/opa_authorization.rego
 
   kubectl delete secret opa-data -n "$acm_namespace" --ignore-not-found
   kubectl create secret generic opa-data -n "$acm_namespace" --from-file=${script_dir}/data.json --from-file=${script_dir}/role_bindings.yaml --from-file=${script_dir}/opa_authorization.rego
 
   rm -rf ${script_dir}/data.json ${script_dir}/role_bindings.yaml ${script_dir}/opa_authorization.rego
 
-  curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-rbac/$TAG/deploy/operator.yaml.template" |
+  curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-rbac/$branch/deploy/operator.yaml.template" |
     REGISTRY=quay.io/open-cluster-management-hub-of-hubs IMAGE_TAG="$TAG" COMPONENT=hub-of-hubs-rbac envsubst | kubectl apply -f - -n "$acm_namespace"
 
-  curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-nonk8s-api/$TAG/deploy/operator.yaml.template" |
+  curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-nonk8s-api/$branch/deploy/operator.yaml.template" |
     REGISTRY=quay.io/open-cluster-management-hub-of-hubs IMAGE_TAG="$TAG" COMPONENT=hub-of-hubs-nonk8s-api envsubst | kubectl apply -f - -n "$acm_namespace"
 
 
-  curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-nonk8s-api/$TAG/deploy/ingress.yaml.template" |
+  curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-nonk8s-api/$branch/deploy/ingress.yaml.template" |
     COMPONENT=hub-of-hubs-nonk8s-api envsubst | kubectl apply -f - -n "$acm_namespace"
+
+  # deploy hub cluster controller
+  rm -rf hub-cluster-controller
+  git clone https://github.com/stolostron/hub-cluster-controller.git
+  cd hub-cluster-controller
+  git checkout $branch
+  kubectl apply -k deploy
+
+  # deploy hub-of-hubs addon controller
+  rm -rf hub-of-hubs-addon
+  git clone https://github.com/stolostron/hub-of-hubs-addon.git
+  cd hub-of-hubs-addon
+  git checkout $branch
+  kubectl apply -k deploy
+
 }
 
 function deploy_helm_charts() {
@@ -99,7 +118,7 @@ function deploy_helm_charts() {
   rm -rf hub-of-hubs-console-chart
   git clone https://github.com/stolostron/hub-of-hubs-console-chart.git
   cd hub-of-hubs-console-chart
-  git checkout $TAG
+  git checkout $branch
   helm get values -a -n "$acm_namespace" $(helm ls -n "$acm_namespace" | cut -d' ' -f1 | grep console-chart) -o yaml > values.yaml
   kubectl delete appsub console-chart-sub -n "$acm_namespace" --ignore-not-found
   cat values.yaml |
@@ -131,7 +150,7 @@ if [ -z "${DATABASE_URL_HOH-}" ] && [ -z "${DATABASE_URL_TRANSPORT-}" ]; then
   rm -rf hub-of-hubs-postgresql
   git clone https://github.com/stolostron/hub-of-hubs-postgresql
   cd hub-of-hubs-postgresql/pgo
-  git checkout $TAG
+  git checkout $branch
   IMAGE=quay.io/open-cluster-management-hub-of-hubs/postgresql-ansible:$TAG ./setup.sh
   cd ../../
   rm -rf hub-of-hubs-postgresql

--- a/deploy/deploy_hub_of_hubs.sh
+++ b/deploy/deploy_hub_of_hubs.sh
@@ -153,15 +153,15 @@ function deploy_helm_charts() {
   deploy_component "grc-chart" "release-2.4" deploy_grc_chart_action
 }
 
+function deploy_hub_of_hubs_postgresql_action() {
+  cd ./pgo
+  IMAGE=quay.io/open-cluster-management-hub-of-hubs/postgresql-ansible:$TAG ./setup.sh
+  cd ..
+}
+
 # always check whether DATABASE_URL_HOH and DATABASE_URL_TRANSPORT are set, if not - install PGO and use its secrets
 if [ -z "${DATABASE_URL_HOH-}" ] && [ -z "${DATABASE_URL_TRANSPORT-}" ]; then
-  rm -rf hub-of-hubs-postgresql
-  git clone https://github.com/stolostron/hub-of-hubs-postgresql
-  cd hub-of-hubs-postgresql/pgo
-  git checkout $branch
-  IMAGE=quay.io/open-cluster-management-hub-of-hubs/postgresql-ansible:$TAG ./setup.sh
-  cd ../../
-  rm -rf hub-of-hubs-postgresql
+  deploy_component "hub-of-hubs-postgresql" "$branch" deploy_hub_of_hubs_postgresql_action
 
   pg_namespace="hoh-postgres"
   process_user="hoh-pguser-hoh-process-user"

--- a/deploy/deploy_hub_of_hubs.sh
+++ b/deploy/deploy_hub_of_hubs.sh
@@ -89,7 +89,7 @@ function deploy_hoh_controllers() {
   envsubst < ./deploy/deployment.yaml.tmpl > ./deploy/deployment.yaml
   kubectl apply -k ./deploy
   cd ..
-  rm -rf hub-cluster-controller
+  rm -rf hub-of-hubs-addon
 }
 
 function deploy_rbac() {

--- a/deploy/deploy_hub_of_hubs_agent_sync_service.sh
+++ b/deploy/deploy_hub_of_hubs_agent_sync_service.sh
@@ -9,5 +9,5 @@ set -o nounset
 css_sync_service_port=${CSS_SYNC_SERVICE_PORT:-9689}
 ess_sync_service_listening_port=8090
 
-curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-sync-service/$TAG/ess/ess.yaml.template" |
+curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-sync-service/$branch/ess/ess.yaml.template" |
     CSS_HOST="$CSS_SYNC_SERVICE_HOST" CSS_PORT="$css_sync_service_port" LISTENING_PORT="$ess_sync_service_listening_port" envsubst | kubectl apply -f -

--- a/deploy/deploy_hub_of_hubs_sync_service.sh
+++ b/deploy/deploy_hub_of_hubs_sync_service.sh
@@ -8,5 +8,5 @@ set -o nounset
 
 css_sync_service_port=${CSS_SYNC_SERVICE_PORT:-9689}
 
-curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-sync-service/$TAG/css/css.yaml.template" |
+curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-sync-service/$branch/css/css.yaml.template" |
     CSS_PORT="$css_sync_service_port" envsubst | kubectl apply -f -

--- a/deploy/deploy_kafka.sh
+++ b/deploy/deploy_kafka.sh
@@ -10,7 +10,7 @@ set -o nounset
 kubectl create namespace kafka --dry-run=client -o yaml | kubectl apply -f -
 
 # deploy AMQ streams operator
-curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-kafka-transport/$TAG/deploy/amq_streams_operator.yaml" | kubectl apply -f -
+curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-kafka-transport/$branch/deploy/amq_streams_operator.yaml" | kubectl apply -f -
 
 # wait until operator is ready
 operator_deployed=$(kubectl -n kafka get Deployment/amq-streams-cluster-operator-v1.7.3 --ignore-not-found)
@@ -22,7 +22,7 @@ done
 kubectl -n kafka wait --for=condition=Available Deployment/amq-streams-cluster-operator-v1.7.3 --timeout=600s
 
 # deploy Kafka cluster CR
-curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-kafka-transport/$TAG/deploy/kafka-cluster.yaml" | kubectl apply -f -
+curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-kafka-transport/$branch/deploy/kafka-cluster.yaml" | kubectl apply -f -
 
 # wait until kafka cluster is ready
 cluster_is_ready=$(kubectl -n kafka get kafka.kafka.strimzi.io/kafka-brokers-cluster -o jsonpath={.status.listeners} --ignore-not-found)

--- a/deploy/undeploy_hub_of_hubs.sh
+++ b/deploy/undeploy_hub_of_hubs.sh
@@ -89,4 +89,4 @@ cd hub-of-hubs-addon
 git checkout $branch
 kubectl delete -k ./deploy --ignore-not-found
 cd ..
-rm -rf hub-cluster-controller
+rm -rf hub-of-hubs-addon

--- a/deploy/undeploy_hub_of_hubs.sh
+++ b/deploy/undeploy_hub_of_hubs.sh
@@ -7,6 +7,10 @@ set -o errexit
 set -o nounset
 
 echo "using kubeconfig $KUBECONFIG"
+branch=$TAG
+if [ $TAG == "latest" ]; then
+  branch="main"
+fi
 
 acm_namespace=open-cluster-management
 
@@ -14,27 +18,27 @@ helm uninstall console-chart -n "$acm_namespace" 2> /dev/null || true
 helm uninstall grc -n "$acm_namespace" 2> /dev/null || true
 kubectl annotate mch multiclusterhub mch-pause=false -n "$acm_namespace" --overwrite
 
-curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-nonk8s-api/$TAG/deploy/ingress.yaml.template" |
+curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-nonk8s-api/$branch/deploy/ingress.yaml.template" |
     COMPONENT=hub-of-hubs-nonk8s-api envsubst | kubectl delete -f - -n "$acm_namespace" --ignore-not-found
 
-curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-nonk8s-api/$TAG/deploy/operator.yaml.template" |
+curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-nonk8s-api/$branch/deploy/operator.yaml.template" |
     REGISTRY=quay.io/open-cluster-management-hub-of-hubs IMAGE_TAG="$TAG" COMPONENT=hub-of-hubs-nonk8s-api envsubst | kubectl delete -f - -n "$acm_namespace" --ignore-not-found
 
-curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-rbac/$TAG/deploy/operator.yaml.template" |
+curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-rbac/$branch/deploy/operator.yaml.template" |
     REGISTRY=quay.io/open-cluster-management-hub-of-hubs IMAGE_TAG="$TAG" COMPONENT=hub-of-hubs-rbac envsubst | kubectl delete -f - -n "$acm_namespace" --ignore-not-found
 
 kubectl delete secret opa-data -n "$acm_namespace" --ignore-not-found
 
-curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-spec-sync/$TAG/deploy/operator.yaml.template" |
+curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-spec-sync/$branch/deploy/operator.yaml.template" |
     REGISTRY=quay.io/open-cluster-management-hub-of-hubs IMAGE_TAG="$TAG" COMPONENT=hub-of-hubs-spec-sync envsubst | kubectl delete -f - -n "$acm_namespace" --ignore-not-found
-curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-status-sync/$TAG/deploy/operator.yaml.template" |
+curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-status-sync/$branch/deploy/operator.yaml.template" |
     REGISTRY=quay.io/open-cluster-management-hub-of-hubs IMAGE_TAG="$TAG" COMPONENT=hub-of-hubs-status-sync envsubst | kubectl delete -f - -n "$acm_namespace" --ignore-not-found
 
 kubectl delete secret hub-of-hubs-database-secret -n "$acm_namespace" --ignore-not-found
 
-curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-spec-transport-bridge/$TAG/deploy/hub-of-hubs-spec-transport-bridge.yaml.template" |
+curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-spec-transport-bridge/$branch/deploy/hub-of-hubs-spec-transport-bridge.yaml.template" |
     envsubst | kubectl delete -f - -n "$acm_namespace" --ignore-not-found
-curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-status-transport-bridge/$TAG/deploy/hub-of-hubs-status-transport-bridge.yaml.template" |
+curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-status-transport-bridge/$branch/deploy/hub-of-hubs-status-transport-bridge.yaml.template" |
     envsubst | kubectl delete -f - -n "$acm_namespace" --ignore-not-found
 
 kubectl delete secret hub-of-hubs-database-secret-transport-bridge-secret -n "$acm_namespace" --ignore-not-found
@@ -43,9 +47,9 @@ kubectl delete secret hub-of-hubs-database-secret-transport-bridge-secret -n "$a
 hoh_config_crd_exists=$(kubectl get crd configs.hub-of-hubs.open-cluster-management.io --ignore-not-found)
 if [[ ! -z "$hoh_config_crd_exists" ]]; then
   # replace the existing HoH config to make sure no finalizer is found
-  kubectl replace -f "https://raw.githubusercontent.com/stolostron/hub-of-hubs-crds/$TAG/cr-examples/hub-of-hubs.open-cluster-management.io_config_cr.yaml" -n hoh-system
+  kubectl replace -f "https://raw.githubusercontent.com/stolostron/hub-of-hubs-crds/$branch/cr-examples/hub-of-hubs.open-cluster-management.io_config_cr.yaml" -n hoh-system
   # delete the HoH config CRD
-  kubectl delete -f "https://raw.githubusercontent.com/stolostron/hub-of-hubs-crds/$TAG/crds/hub-of-hubs.open-cluster-management.io_config_crd.yaml"
+  kubectl delete -f "https://raw.githubusercontent.com/stolostron/hub-of-hubs-crds/$branch/crds/hub-of-hubs.open-cluster-management.io_config_crd.yaml"
 fi
 
 kubectl annotate mch multiclusterhub --overwrite mch-imageOverridesCM= -n "$acm_namespace"
@@ -63,8 +67,26 @@ kubectl delete namespace sync-service --ignore-not-found
 rm -rf hub-of-hubs-postgresql
 git clone https://github.com/stolostron/hub-of-hubs-postgresql
 cd hub-of-hubs-postgresql
-git checkout $TAG
+git checkout $branch
 kubectl delete -k ./pgo/high-availability --ignore-not-found
 kubectl delete -k ./pgo/install --ignore-not-found
 cd ..
 rm -rf hub-of-hubs-postgresql
+
+# uninstall hub cluster controller
+rm -rf hub-cluster-controller
+git clone https://github.com/stolostron/hub-cluster-controller.git
+cd hub-cluster-controller
+git checkout $branch
+kubectl delete -k ./deploy --ignore-not-found
+cd ..
+rm -rf hub-cluster-controller
+
+# uninstall hub-of-hubs addon controller
+rm -rf hub-of-hubs-addon
+git clone https://github.com/stolostron/hub-of-hubs-addon.git
+cd hub-of-hubs-addon
+git checkout $branch
+kubectl delete -k ./deploy --ignore-not-found
+cd ..
+rm -rf hub-cluster-controller

--- a/deploy/undeploy_hub_of_hubs.sh
+++ b/deploy/undeploy_hub_of_hubs.sh
@@ -12,6 +12,16 @@ if [ $TAG == "latest" ]; then
   branch="main"
 fi
 
+function uninstall_component() {
+    rm -rf $1
+    git clone https://github.com/stolostron/$1.git
+    cd $1
+    git checkout $2
+    $3
+    cd ..
+    rm -rf $1
+}
+
 acm_namespace=open-cluster-management
 
 helm uninstall console-chart -n "$acm_namespace" 2> /dev/null || true
@@ -64,29 +74,10 @@ kubectl delete namespace kafka --ignore-not-found
 kubectl delete namespace sync-service --ignore-not-found
 
 # uninstall PGO
-rm -rf hub-of-hubs-postgresql
-git clone https://github.com/stolostron/hub-of-hubs-postgresql
-cd hub-of-hubs-postgresql
-git checkout $branch
-kubectl delete -k ./pgo/high-availability --ignore-not-found
-kubectl delete -k ./pgo/install --ignore-not-found
-cd ..
-rm -rf hub-of-hubs-postgresql
+uninstall_component "hub-of-hubs-postgresql" "$branch" "kubectl delete -k ./pgo/install -k ./pgo/high-availability --ignore-not-found"
 
 # uninstall hub cluster controller
-rm -rf hub-cluster-controller
-git clone https://github.com/stolostron/hub-cluster-controller.git
-cd hub-cluster-controller
-git checkout $branch
-kubectl delete -k ./deploy --ignore-not-found
-cd ..
-rm -rf hub-cluster-controller
+uninstall_component "hub-cluster-controller" "$branch" "kubectl delete -k ./deploy --ignore-not-found"
 
 # uninstall hub-of-hubs addon controller
-rm -rf hub-of-hubs-addon
-git clone https://github.com/stolostron/hub-of-hubs-addon.git
-cd hub-of-hubs-addon
-git checkout $branch
-kubectl delete -k ./deploy --ignore-not-found
-cd ..
-rm -rf hub-of-hubs-addon
+uninstall_component "hub-of-hubs-addon" "$branch" "kubectl delete -k ./deploy --ignore-not-found"

--- a/deploy/undeploy_hub_of_hubs_agent.sh
+++ b/deploy/undeploy_hub_of_hubs_agent.sh
@@ -5,19 +5,23 @@
 
 set -o errexit
 set -o nounset
+branch=$TAG
+if [ $TAG == "latest" ]; then
+  branch="main"
+fi
 
 acm_namespace=open-cluster-management
 
 echo "using kubeconfig $KUBECONFIG"
 kubectl delete namespace hoh-system --ignore-not-found
 
-curl -s "https://raw.githubusercontent.com/stolostron/leaf-hub-spec-sync/$TAG/deploy/leaf-hub-spec-sync.yaml.template" | \
+curl -s "https://raw.githubusercontent.com/stolostron/leaf-hub-spec-sync/$branch/deploy/leaf-hub-spec-sync.yaml.template" | \
     envsubst | kubectl delete -f - --ignore-not-found
-curl -s "https://raw.githubusercontent.com/stolostron/leaf-hub-status-sync/$TAG/deploy/leaf-hub-status-sync.yaml.template" | \
+curl -s "https://raw.githubusercontent.com/stolostron/leaf-hub-status-sync/$branch/deploy/leaf-hub-status-sync.yaml.template" | \
     envsubst | kubectl delete -f - --ignore-not-found
     
 # delete the HoH config CRD
-kubectl delete -f "https://raw.githubusercontent.com/stolostron/hub-of-hubs-crds/$TAG/crds/hub-of-hubs.open-cluster-management.io_config_crd.yaml" \
+kubectl delete -f "https://raw.githubusercontent.com/stolostron/hub-of-hubs-crds/$branch/crds/hub-of-hubs.open-cluster-management.io_config_crd.yaml" \
 	--ignore-not-found
 
 # delete sync-service namespace if exists - this will also delete all living resources inside the sync-service namespace


### PR DESCRIPTION
This PR is used to enable deploy `hub-cluster-controller` and `hub-of-hubs-addon-controller` into HoH cluster by using our existing deployment scripts. Also enable test with the `latest` image tag. I have published all the required images with the latest tag from `main` branch.

After deployed hoh, the agent deployment can be optional. It can be done via `hub-cluster-controller` if the leaf hub cluster is a managed cluster of HoH cluster.