### PR TITLE
gitops

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ See [deployment scripts](deploy).
 
 * [hub-of-hubs-nonk8s-api](https://github.com/stolostron/hub-of-hubs-nonk8s-api)
 
+#### Non-Kubernetes GitOps
+
+* [hub-of-hubs-nonk8s-gitops](https://github.com/stolostron/hub-of-hubs-nonk8s-gitops)
+
 #### UI
 
 * [hub-of-hubs-console](https://github.com/stolostron/hub-of-hubs-console)

--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ See [deployment scripts](deploy).
 
 * [hub-of-hubs-nonk8s-api](https://github.com/stolostron/hub-of-hubs-nonk8s-api)
 
-#### Non-Kubernetes GitOps
+#### GitOps
 
-* [hub-of-hubs-nonk8s-gitops](https://github.com/stolostron/hub-of-hubs-nonk8s-gitops)
+* [hub-of-hubs-gitops](https://github.com/stolostron/hub-of-hubs-gitops)
 
 #### UI
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -35,10 +35,16 @@
 # Hub of Hubs
 
 ### Deploying Hub-of-hubs components
+1.  Set the `GITOPS_NODE_HOSTNAME` to the hostname of a node (e.g., `ip-10-0-171-109`) to run GitOps component, subscriptions operator and
+    their shared PersistentStorage on.
+    ```
+    export GITOPS_NODE_HOSTNAME=...
+    ``` 
 
-```
-KUBECONFIG=$TOP_HUB_CONFIG ./deploy_hub_of_hubs.sh
-```
+1.  Deploy:
+    ```
+    KUBECONFIG=$TOP_HUB_CONFIG ./deploy_hub_of_hubs.sh
+    ```
 
 ### Using Hub-of-Hubs Web Console
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -35,16 +35,9 @@
 # Hub of Hubs
 
 ### Deploying Hub-of-hubs components
-1.  Set the `GITOPS_NODE_HOSTNAME` to the hostname of a node (e.g., `ip-10-0-171-109`) to run GitOps component, subscriptions operator and
-    their shared PersistentStorage on.
-    ```
-    export GITOPS_NODE_HOSTNAME=...
-    ``` 
-
-1.  Deploy:
-    ```
-    KUBECONFIG=$TOP_HUB_CONFIG ./deploy_hub_of_hubs.sh
-    ```
+```
+KUBECONFIG=$TOP_HUB_CONFIG ./deploy_hub_of_hubs.sh
+```
 
 ### Using Hub-of-Hubs Web Console
 

--- a/deploy/deploy_hub_of_hubs.sh
+++ b/deploy/deploy_hub_of_hubs.sh
@@ -133,10 +133,10 @@ function deploy_gitops() {
   pv_and_pvc_exist=$(kubectl -n "$acm_namespace" get persistentvolume hoh-gitops-pv --ignore-not-found)
   if [[ ! -z "$pv_and_pvc_exist" ]]; then
     # if exists, do not change
-    echo "PersistentVolume hoh-gitops-pv already exists and is immutable. Delete manually to before deployment if needed"
+    echo "PersistentVolume hoh-gitops-pv already exists and is immutable."
   else
     # if doesnt exist then deploy PV and PVC
-    node_hostname=$(kubectl get node --selector='!node-role.kubernetes.io/master' -o=jsonpath='{.items[0].metadata.labels.kubernetes\.io\/hostname}')
+    node_hostname=$(kubectl get node --selector='node-role.kubernetes.io/worker' -o=jsonpath='{.items[0].metadata.labels.kubernetes\.io\/hostname}')
     curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-nonk8s-gitops/main/deploy/hub-of-hubs-gitops-pv.yaml" |
       GITOPS_NODE_HOSTNAME=$node_hostname envsubst | kubectl apply -f - -n "$acm_namespace"
   fi

--- a/deploy/deploy_hub_of_hubs.sh
+++ b/deploy/deploy_hub_of_hubs.sh
@@ -136,8 +136,9 @@ function deploy_gitops() {
     echo "PersistentVolume hoh-gitops-pv already exists and is immutable. Delete manually to before deployment if needed"
   else
     # if doesnt exist then deploy PV and PVC
+    node_hostname=$(kubectl get node --selector='!node-role.kubernetes.io/master' -o=jsonpath='{.items[0].metadata.labels.kubernetes\.io\/hostname}')
     curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-nonk8s-gitops/main/deploy/hub-of-hubs-gitops-pv.yaml" |
-      envsubst | kubectl apply -f - -n "$acm_namespace"
+      GITOPS_NODE_HOSTNAME=$node_hostname envsubst | kubectl apply -f - -n "$acm_namespace"
   fi
   # deploy customized Subscription CRD
   curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-nonk8s-gitops/main/deploy/customized-subscriptions-operator/apps.open-cluster-management.io_subscriptions_crd_v1.yaml" |

--- a/deploy/deploy_hub_of_hubs.sh
+++ b/deploy/deploy_hub_of_hubs.sh
@@ -128,7 +128,7 @@ function deploy_helm_charts() {
 
 function deploy_gitops() {
   modified_operator_image='quay.io/maroonayoub/multicloud-operators-subscription@sha256:1c57e1e77ea3c929c7176681d5b64eca43354bbaf00aeb7f7ddb01d3c6d15ad0'
-  nonk8s_gitops_image='quay.io/maroonayoub/hub-of-hubs-nonk8s-gitops:latest'
+  hoh_gitops_image='quay.io/maroonayoub/hub-of-hubs-gitops:latest'
 
   pv_and_pvc_exist=$(kubectl -n "$acm_namespace" get persistentvolume hoh-gitops-pv --ignore-not-found)
   if [[ ! -z "$pv_and_pvc_exist" ]]; then
@@ -137,22 +137,22 @@ function deploy_gitops() {
   else
     # if doesnt exist then deploy PV and PVC
     node_hostname=$(kubectl get node --selector='node-role.kubernetes.io/worker' -o=jsonpath='{.items[0].metadata.labels.kubernetes\.io\/hostname}')
-    curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-nonk8s-gitops/main/deploy/hub-of-hubs-gitops-pv.yaml" |
+    curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-gitops/main/deploy/hub-of-hubs-gitops-pv.yaml" |
       GITOPS_NODE_HOSTNAME=$node_hostname envsubst | kubectl apply -f - -n "$acm_namespace"
   fi
   # deploy customized Subscription CRD
-  curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-nonk8s-gitops/main/deploy/customized-subscriptions-operator/apps.open-cluster-management.io_subscriptions_crd_v1.yaml" |
+  curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-gitops/main/deploy/customized-subscriptions-operator/apps.open-cluster-management.io_subscriptions_crd_v1.yaml" |
     kubectl -n "$acm_namespace" apply -f -
   # create ns for subscriptions
   kubectl create namespace hoh-subscriptions --dry-run=client -o yaml | kubectl apply -f -
   # patch ACM for K8s operator to deploy modified operators
   kubectl -n open-cluster-management patch ClusterServiceVersion \
    advanced-cluster-management.v2.4.2 --type=merge --patch \
-   "$(curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-nonk8s-gitops/main/deploy/customized-subscriptions-operator/operators-subscriptions-deployments-patch.yaml" |
+   "$(curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-gitops/main/deploy/customized-subscriptions-operator/operators-subscriptions-deployments-patch.yaml" |
         MODIFIED_OPERATOR_IMAGE=$modified_operator_image envsubst)"
-  # deploy nonk8s gitops
-  curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-nonk8s-gitops/main/deploy/hub-of-hubs-nonk8s-gitops.yaml.template" |
-      IMAGE=$nonk8s_gitops_image envsubst | kubectl apply -f - -n "$acm_namespace"
+  # deploy hoh gitops
+  curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-gitops/main/deploy/hub-of-hubs-gitops.yaml.template" |
+      IMAGE=$hoh_gitops_image envsubst | kubectl apply -f - -n "$acm_namespace"
 }
 
 # always check whether DATABASE_URL_HOH and DATABASE_URL_TRANSPORT are set, if not - install PGO and use its secrets

--- a/deploy/deploy_hub_of_hubs.sh
+++ b/deploy/deploy_hub_of_hubs.sh
@@ -151,6 +151,7 @@ function deploy_gitops() {
    "$(curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-gitops/main/deploy/customized-subscriptions-operator/operators-subscriptions-deployments-patch.yaml" |
         MODIFIED_OPERATOR_IMAGE=$modified_operator_image envsubst)"
   # deploy hoh gitops
+  oc adm policy add-scc-to-user privileged -z hub-of-hubs-gitops -n open-cluster-management
   curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-gitops/main/deploy/hub-of-hubs-gitops.yaml.template" |
       IMAGE=$hoh_gitops_image envsubst | kubectl apply -f - -n "$acm_namespace"
 }

--- a/deploy/undeploy_hub_of_hubs.sh
+++ b/deploy/undeploy_hub_of_hubs.sh
@@ -36,6 +36,8 @@ curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-spec-transport
     envsubst | kubectl delete -f - -n "$acm_namespace" --ignore-not-found
 curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-status-transport-bridge/$TAG/deploy/hub-of-hubs-status-transport-bridge.yaml.template" |
     envsubst | kubectl delete -f - -n "$acm_namespace" --ignore-not-found
+curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-nonk8s-gitops/main/deploy/hub-of-hubs-nonk8s-gitops.yaml.template" |
+    envsubst | kubectl delete -f - -n "$acm_namespace" --ignore-not-found
 
 kubectl delete secret hub-of-hubs-database-secret-transport-bridge-secret -n "$acm_namespace" --ignore-not-found
 

--- a/deploy/undeploy_hub_of_hubs.sh
+++ b/deploy/undeploy_hub_of_hubs.sh
@@ -34,14 +34,14 @@ curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-status-sync/$T
 # delete subscriptions ns
 kubectl delete namespace hoh-subscriptions --ignore-not-found
 # delete gitops component
-curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-nonk8s-gitops/main/deploy/hub-of-hubs-nonk8s-gitops.yaml.template" |
+curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-gitops/main/deploy/hub-of-hubs-gitops.yaml.template" |
     envsubst | kubectl delete -f - -n "$acm_namespace" --ignore-not-found
 # revert subscriptions operators deployments (in ACM for K8s operator):
 kubectl -n open-cluster-management patch ClusterServiceVersion \
    advanced-cluster-management.v2.4.2 --type=merge --patch \
-   "$(curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-nonk8s-gitops/main/deploy/customized-subscriptions-operator/revert-operators-subscriptions-deployments-patch.yaml")"
+   "$(curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-gitops/main/deploy/customized-subscriptions-operator/revert-operators-subscriptions-deployments-patch.yaml")"
 # delete PV and PVC
-curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-nonk8s-gitops/main/deploy/hub-of-hubs-gitops-pv.yaml" |
+curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-gitops/main/deploy/hub-of-hubs-gitops-pv.yaml" |
       kubectl delete -f - -n "$acm_namespace"
 # ---
 

--- a/deploy/undeploy_hub_of_hubs.sh
+++ b/deploy/undeploy_hub_of_hubs.sh
@@ -36,6 +36,8 @@ kubectl delete namespace hoh-subscriptions --ignore-not-found
 # delete gitops component
 curl -s "https://raw.githubusercontent.com/stolostron/hub-of-hubs-gitops/main/deploy/hub-of-hubs-gitops.yaml.template" |
     envsubst | kubectl delete -f - -n "$acm_namespace" --ignore-not-found
+# undo security-context permission
+oc adm policy remove-scc-from-user privileged -z hub-of-hubs-gitops -n open-cluster-management
 # revert subscriptions operators deployments (in ACM for K8s operator):
 kubectl -n open-cluster-management patch ClusterServiceVersion \
    advanced-cluster-management.v2.4.2 --type=merge --patch \


### PR DESCRIPTION
based on label-management branch:

1.  deploy PV & PVC to be shared by nonk8s-gitops and modified subscriptions operator
2. deploy modified Subscription CRD
3. deploy modified subscriptions operators by patching the ACM for K8s operator (the cluster's main operator)
4. deploy nonk8s-gitops


TODO later: push all images to our org in quay and fix links

Signed-off-by: Maroon Ayoub <maroon.ayoub@ibm.com>