### PR TITLE
Support ACM 2.5

### DIFF
--- a/deploy/deploy_hub_of_hubs.sh
+++ b/deploy/deploy_hub_of_hubs.sh
@@ -71,19 +71,13 @@ function deploy_hoh_controllers() {
     TRANSPORT_TYPE="${transport_type}" IMAGE="quay.io/open-cluster-management-hub-of-hubs/hub-of-hubs-status-transport-bridge:$TAG" envsubst | kubectl apply -f - -n "$acm_namespace"
 
   # deploy hub cluster controller
-  deploy_component "hub-cluster-controller" "$branch" deploy_hub_cluster_controller_action
+  deploy_component "hub-cluster-controller" "$branch" deploy_components_with_environment_variables_action
 
   # deploy hub of hubs addon controller
-  deploy_component "hub-of-hubs-addon" "$branch" deploy_hub_of_hubs_addon_action
+  deploy_component "hub-of-hubs-addon" "$branch" deploy_components_with_environment_variables_action
 }
 
-function deploy_hub_of_hubs_addon_action() {
-  mv ./deploy/deployment.yaml ./deploy/deployment.yaml.tmpl
-  envsubst < ./deploy/deployment.yaml.tmpl > ./deploy/deployment.yaml
-  kubectl apply -n "$acm_namespace" -k ./deploy
-}
-
-function deploy_hub_cluster_controller_action() {
+function deploy_components_with_environment_variables_action() {
   mv ./deploy/deployment.yaml ./deploy/deployment.yaml.tmpl
   envsubst < ./deploy/deployment.yaml.tmpl > ./deploy/deployment.yaml
   kubectl apply -n "$acm_namespace" -k ./deploy


### PR DESCRIPTION
couple of changes:
1. there is a new component `grc-policy-addon-controller` introduced for grc and remove the `grc-grcui` and `grc-grcuiapi`. so we need to fork it and add back the removed components.
2. update the `governance-policy-propagator` to align with `release-2.5`.
3. Get the `SNAPSHOT` environment to enable deploy ACM Hub with the specified snapshot.