### PR TITLE
add hosted cluster name to addon deploy manifests.

### DIFF
--- a/doc/hypershift/manifests/manifestwork-config-policy-controller.yaml
+++ b/doc/hypershift/manifests/manifestwork-config-policy-controller.yaml
@@ -3,7 +3,7 @@ kind: ManifestWork
 metadata:
   labels:
     open-cluster-management.io/addon-name: config-policy-controller
-  name: addon-config-policy-controller-deploy-hosted
+  name: addon-config-policy-controller-${HYPERSHIFT_MANAGED_CLUSTER_NAME}-hosted
   namespace: ${HYPERSHIFT_MGMT_CLUSTER}
 spec:
   workload:

--- a/doc/hypershift/manifests/manifestwork-policy-framework.yaml
+++ b/doc/hypershift/manifests/manifestwork-policy-framework.yaml
@@ -3,7 +3,7 @@ kind: ManifestWork
 metadata:
   labels:
     open-cluster-management.io/addon-name: governance-policy-framework
-  name: addon-governance-policy-framework-deploy-hosted
+  name: addon-governance-policy-framework-${HYPERSHIFT_MANAGED_CLUSTER_NAME}-hosted
   namespace: ${HYPERSHIFT_MGMT_CLUSTER}
 spec:
   workload:


### PR DESCRIPTION
add hosted cluster name to addon deploy manifests so that we can create manifestworks for different hosted cluster in hypershift management cluster namespace.

Signed-off-by: morvencao <lcao@redhat.com>